### PR TITLE
Add Tiobe TiCS to the CI

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,12 @@
+name: Tiobe TiCS Analysis
+
+on:
+    workflow_dispatch:
+    schedule:
+    - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
+
+jobs:
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        secrets: inherit

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,7 +48,6 @@ async def test_profile_store_relation(ops_test: OpsTest):
         ops_test.model.wait_for_idle(
             apps=[PSCLOUD, "parca-agent"],
             status="active",
-            raise_on_blocked=True,
             timeout=1000,
         ),
     )


### PR DESCRIPTION
Add a GH workflow to run a cronjob (every week on Monday) to run Tiobe TiCS scan on this repo.