### PR TITLE
Update external URL format for ParcaStoreEndpointProvider

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ class PolarSignalsCloudIntegratorCharm(ops.CharmBase):
             self,
             port=443,
             insecure=False,
-            external_url="https://grpc.polarsignals.com",
+            external_url="grpc.polarsignals.com:443",
             token_generator=lambda: self.config["bearer_token"],
             relation_name="parca-store-endpoint",
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,7 +35,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "parca-agent/0")
 
         expected = {
-            "remote-store-address": "https://grpc.polarsignals.com",
+            "remote-store-address": "grpc.polarsignals.com:443",
             "remote-store-bearer-token": "deadbeef",
             "remote-store-insecure": "false",
         }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

```
level=warning msg="Failed to setup gRPC connection (try 4 of 5): context deadline exceeded: connection error: desc = \"transport: Error while dialing: dial tcp: lookup tcp///grpc.polarsignals.com: unknown port\""
```

## Solution
<!-- A summary of the solution addressing the above issue -->

Allow the snap to connect to Polar Signals

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
